### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,10 @@
 	"defaultProject": "frontsoulend",
 	"defaultBase": "main",
 	"namedInputs": {
-		"default": ["{projectRoot}/**/*", "sharedGlobals"],
+		"default": [
+			"{projectRoot}/**/*",
+			"sharedGlobals"
+		],
 		"production": [
 			"default",
 			"!{projectRoot}/.eslintrc.json",
@@ -14,21 +17,36 @@
 			"!{projectRoot}/src/test-setup.[jt]s",
 			"!{projectRoot}/test-setup.[jt]s"
 		],
-		"sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
+		"sharedGlobals": [
+			"{workspaceRoot}/.github/workflows/ci.yml"
+		]
 	},
 	"targetDefaults": {
 		"@angular-devkit/build-angular:application": {
 			"cache": true,
-			"dependsOn": ["^build"],
-			"inputs": ["production", "^production"]
+			"dependsOn": [
+				"^build"
+			],
+			"inputs": [
+				"production",
+				"^production"
+			]
 		},
 		"@nx/eslint:lint": {
 			"cache": true,
-			"inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/.eslintignore"]
+			"inputs": [
+				"default",
+				"{workspaceRoot}/.eslintrc.json",
+				"{workspaceRoot}/.eslintignore"
+			]
 		},
 		"@nx/jest:jest": {
 			"cache": true,
-			"inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+			"inputs": [
+				"default",
+				"^production",
+				"{workspaceRoot}/jest.preset.js"
+			],
 			"options": {
 				"passWithNoTests": true
 			},
@@ -41,10 +59,16 @@
 		},
 		"nx-stylelint:lint": {
 			"cache": true,
-			"inputs": ["default", "{workspaceRoot}/.stylelint.json", "{workspaceRoot}/.stylelintignore"]
+			"inputs": [
+				"default",
+				"{workspaceRoot}/.stylelint.json",
+				"{workspaceRoot}/.stylelintignore"
+			]
 		},
 		"e2e-ci--**/*": {
-			"dependsOn": ["^build"]
+			"dependsOn": [
+				"^build"
+			]
 		}
 	},
 	"plugins": [
@@ -133,5 +157,6 @@
 		"@ngneat/spectator:spectator-service": {
 			"flat": false
 		}
-	}
+	},
+	"nxCloudId": "672be036b76a0e014484fa2b"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/672be02396919a39aee99c79/workspaces/672be036b76a0e014484fa2b

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.